### PR TITLE
Hotfix subsense confidence

### DIFF
--- a/cpp/OcvPersonDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/OcvPersonDetection/plugin-files/descriptor/descriptor.json
@@ -111,26 +111,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/motion/MogMotionDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/motion/MogMotionDetection/plugin-files/descriptor/descriptor.json
@@ -110,26 +110,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/motion/SubsenseMotionDetection/CMakeLists.txt
+++ b/cpp/motion/SubsenseMotionDetection/CMakeLists.txt
@@ -47,8 +47,8 @@ add_subdirectory(SubSense)
 
 include(../STRUCK/CMakeLists.txt)
 
-set(MOTION_UTILS_DIR ../Utils)
-set(MOTION_UTILS_SRC ${MOTION_UTILS_DIR}/MotionDetectionUtils.cpp ${MOTION_UTILS_DIR}/MotionDetectionUtils.h)
+set(MOTION_UTILS_DIR ${CMAKE_SOURCE_DIR}/motion/Utils)
+set(MOTION_UTILS_SRC ${MOTION_UTILS_DIR}/MotionDetectionUtils.cpp ${MOTION_UTILS_DIR}/MotionDetectionUtils.h ${MOTION_UTILS_DIR}/AssignDetectionConfidence.cpp ${MOTION_UTILS_DIR}/AssignDetectionConfidence.h)
 include_directories(${MOTION_UTILS_DIR})
 
 set(SUBSENSE_MOTION_SOURCE_FILES MotionDetection_Subsense.cpp MotionDetection_Subsense.h ${MOTION_UTILS_SRC})

--- a/cpp/motion/SubsenseMotionDetection/CMakeLists.txt
+++ b/cpp/motion/SubsenseMotionDetection/CMakeLists.txt
@@ -48,7 +48,7 @@ add_subdirectory(SubSense)
 include(../STRUCK/CMakeLists.txt)
 
 set(MOTION_UTILS_DIR ${CMAKE_SOURCE_DIR}/motion/Utils)
-set(MOTION_UTILS_SRC ${MOTION_UTILS_DIR}/MotionDetectionUtils.cpp ${MOTION_UTILS_DIR}/MotionDetectionUtils.h ${MOTION_UTILS_DIR}/AssignDetectionConfidence.cpp ${MOTION_UTILS_DIR}/AssignDetectionConfidence.h)
+set(MOTION_UTILS_SRC ${MOTION_UTILS_DIR}/MotionDetectionUtils.cpp ${MOTION_UTILS_DIR}/MotionDetectionUtils.h)
 include_directories(${MOTION_UTILS_DIR})
 
 set(SUBSENSE_MOTION_SOURCE_FILES MotionDetection_Subsense.cpp MotionDetection_Subsense.h ${MOTION_UTILS_SRC})

--- a/cpp/motion/SubsenseMotionDetection/CMakeLists.txt
+++ b/cpp/motion/SubsenseMotionDetection/CMakeLists.txt
@@ -47,7 +47,7 @@ add_subdirectory(SubSense)
 
 include(../STRUCK/CMakeLists.txt)
 
-set(MOTION_UTILS_DIR ${CMAKE_SOURCE_DIR}/motion/Utils)
+set(MOTION_UTILS_DIR ../Utils)
 set(MOTION_UTILS_SRC ${MOTION_UTILS_DIR}/MotionDetectionUtils.cpp ${MOTION_UTILS_DIR}/MotionDetectionUtils.h)
 include_directories(${MOTION_UTILS_DIR})
 

--- a/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
@@ -39,7 +39,6 @@
 #include "SubSense/BackgroundSubtractorSuBSENSE.h"
 #include "struck.h"
 #include "MotionDetectionUtils.h"
-#include "AssignDetectionConfidence.h"
 
 using std::pair;
 

--- a/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
@@ -39,6 +39,7 @@
 #include "SubSense/BackgroundSubtractorSuBSENSE.h"
 #include "struck.h"
 #include "MotionDetectionUtils.h"
+#include "AssignDetectionConfidence.h"
 
 using std::pair;
 
@@ -238,12 +239,9 @@ MPFDetectionError MotionDetection_Subsense::GetDetectionsFromVideoCapture(const 
     // Assign a confidence value to each detection
     float distance_factor = parameters["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
     float size_factor = parameters["SIZE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
-    if ((distance_factor > 0) || (size_factor > 0)) {
-        for(MPFVideoTrack &track : tracks) {
-            AssignDetectionConfidence(track, distance_factor, size_factor);
-        }
+    for(MPFVideoTrack &track : tracks) {
+        AssignDetectionConfidence(track, distance_factor, size_factor);
     }
-
 
     if (parameters["VERBOSE"].toInt() > 0) {
         //now print tracks if available

--- a/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
@@ -45,6 +45,9 @@ using std::pair;
 using namespace MPF;
 using namespace COMPONENT;
 
+void AssignTrackConfidence(MPF::COMPONENT::MPFVideoTrack &track,
+                           float distance_factor,
+                           float size_factor);
 
 void displayTracks(QString origPath, int frameCount, std::vector<MPFVideoTrack> tracks);
 
@@ -236,6 +239,16 @@ MPFDetectionError MotionDetection_Subsense::GetDetectionsFromVideoCapture(const 
     // Close video capture
     video_capture.Release();
 
+    // Assign a confidence value to each detection
+    float distance_factor = parameters["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
+    float size_factor = parameters["SIZE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
+    if ((distance_factor > 0) || (size_factor > 0)) {
+        for(MPFVideoTrack &track : tracks) {
+            AssignTrackConfidence(track, distance_factor, size_factor);
+        }
+    }
+
+
     if (parameters["VERBOSE"].toInt() > 0) {
         //now print tracks if available
         if (!tracks.empty()) {
@@ -301,6 +314,60 @@ MPFDetectionError MotionDetection_Subsense::GetDetections(const MPFImageJob &job
         return Utils::HandleDetectionException(job, motion_logger);
     }
 }
+
+
+
+void AssignTrackConfidence(MPF::COMPONENT::MPFVideoTrack &track,
+                           float distance_factor,
+                           float size_factor) {
+    // Distance confidence: Detections closer to the "center" of the
+    // track have higher confidence. Determine which detection is at the center
+    // of the track, and assign it the highest confidence (1.0). The rest of the
+    // detections are assigned a confidence based on their distance
+    // from the "center", with the first and last detections in the
+    // track having confidence equal to 0. If there are an even number of
+    // detections in the track, then the two detections nearest the
+    // track center will both be given confidence equal to 1.0.
+
+    // Size confidence: Detections that have greater area in their
+    // bounding boxes have higher confidence. Each detection has a
+    // size confidence equal to the ratio of the size of its bounding
+    // box to the maximum size bounding box in the track.
+
+    int number_of_detections = track.frame_locations.size();
+    float max_size = 0;
+    for (auto entry: track.frame_locations) {
+        float entry_size = static_cast<float>(entry.second.width * entry.second.height);
+        if (entry_size > max_size) {
+            max_size = entry_size;
+        }
+    }
+
+    if (number_of_detections <= 2) {
+        for (auto &entry : track.frame_locations) {
+            MPFImageLocation &loc = entry.second;
+            loc.confidence = distance_factor + size_factor*(static_cast<float>(loc.height*loc.width)/max_size);
+        }
+    }
+    else {
+        float center = static_cast<float>(number_of_detections)/2.0;
+        int center_index = static_cast<int>(center);
+        float confidence_incr = 1.0/center_index;
+
+        auto first = track.frame_locations.begin();
+        auto last = track.frame_locations.rbegin();
+        for (int i = 0; i <= center_index; ++i) {
+            MPFImageLocation &loc1 = (first++)->second;
+            MPFImageLocation &loc2 = (last++)->second;
+            loc1.confidence = distance_factor*(i*confidence_incr) +
+                              size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
+            loc2.confidence = distance_factor*(i*confidence_incr) +
+                              size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
+        }
+    }
+}
+
+
 
 // NOTE: This only draws a bounding box around the first detection in each track
 void displayTracks(QString origPath, int frameCount, std::vector<MPFVideoTrack> tracks) {

--- a/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/MotionDetection_Subsense.cpp
@@ -45,10 +45,6 @@ using std::pair;
 using namespace MPF;
 using namespace COMPONENT;
 
-void AssignTrackConfidence(MPF::COMPONENT::MPFVideoTrack &track,
-                           float distance_factor,
-                           float size_factor);
-
 void displayTracks(QString origPath, int frameCount, std::vector<MPFVideoTrack> tracks);
 
 MotionDetection_Subsense::MotionDetection_Subsense() {
@@ -244,7 +240,7 @@ MPFDetectionError MotionDetection_Subsense::GetDetectionsFromVideoCapture(const 
     float size_factor = parameters["SIZE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
     if ((distance_factor > 0) || (size_factor > 0)) {
         for(MPFVideoTrack &track : tracks) {
-            AssignTrackConfidence(track, distance_factor, size_factor);
+            AssignDetectionConfidence(track, distance_factor, size_factor);
         }
     }
 
@@ -312,58 +308,6 @@ MPFDetectionError MotionDetection_Subsense::GetDetections(const MPFImageJob &job
     }
     catch (...) {
         return Utils::HandleDetectionException(job, motion_logger);
-    }
-}
-
-
-
-void AssignTrackConfidence(MPF::COMPONENT::MPFVideoTrack &track,
-                           float distance_factor,
-                           float size_factor) {
-    // Distance confidence: Detections closer to the "center" of the
-    // track have higher confidence. Determine which detection is at the center
-    // of the track, and assign it the highest confidence (1.0). The rest of the
-    // detections are assigned a confidence based on their distance
-    // from the "center", with the first and last detections in the
-    // track having confidence equal to 0. If there are an even number of
-    // detections in the track, then the two detections nearest the
-    // track center will both be given confidence equal to 1.0.
-
-    // Size confidence: Detections that have greater area in their
-    // bounding boxes have higher confidence. Each detection has a
-    // size confidence equal to the ratio of the size of its bounding
-    // box to the maximum size bounding box in the track.
-
-    int number_of_detections = track.frame_locations.size();
-    float max_size = 0;
-    for (auto entry: track.frame_locations) {
-        float entry_size = static_cast<float>(entry.second.width * entry.second.height);
-        if (entry_size > max_size) {
-            max_size = entry_size;
-        }
-    }
-
-    if (number_of_detections <= 2) {
-        for (auto &entry : track.frame_locations) {
-            MPFImageLocation &loc = entry.second;
-            loc.confidence = distance_factor + size_factor*(static_cast<float>(loc.height*loc.width)/max_size);
-        }
-    }
-    else {
-        float center = static_cast<float>(number_of_detections)/2.0;
-        int center_index = static_cast<int>(center);
-        float confidence_incr = 1.0/center_index;
-
-        auto first = track.frame_locations.begin();
-        auto last = track.frame_locations.rbegin();
-        for (int i = 0; i <= center_index; ++i) {
-            MPFImageLocation &loc1 = (first++)->second;
-            MPFImageLocation &loc2 = (last++)->second;
-            loc1.confidence = distance_factor*(i*confidence_incr) +
-                              size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
-            loc2.confidence = distance_factor*(i*confidence_incr) +
-                              size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
-        }
     }
 }
 

--- a/cpp/motion/SubsenseMotionDetection/StreamingMotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/StreamingMotionDetection_Subsense.cpp
@@ -32,7 +32,6 @@
 #include <MPFSimpleConfigLoader.h>
 #include "StreamingMotionDetection_Subsense.h"
 #include "MotionDetectionUtils.h"
-#include "AssignDetectionConfidence.h"
 
 using namespace MPF;
 using namespace COMPONENT;

--- a/cpp/motion/SubsenseMotionDetection/StreamingMotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/StreamingMotionDetection_Subsense.cpp
@@ -32,6 +32,7 @@
 #include <MPFSimpleConfigLoader.h>
 #include "StreamingMotionDetection_Subsense.h"
 #include "MotionDetectionUtils.h"
+#include "AssignDetectionConfidence.h"
 
 using namespace MPF;
 using namespace COMPONENT;
@@ -262,12 +263,9 @@ vector<MPFVideoTrack> SubsenseStreamingDetection::EndSegment() {
     // Assign a confidence value to each detection
     float distance_factor = parameters_["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
     float size_factor = parameters_["SIZE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
-    if ((distance_factor > 0) || (size_factor > 0)) {
-        for(MPFVideoTrack &track : tracks_) {
-            AssignDetectionConfidence(track, distance_factor, size_factor);
-        }
+    for(MPFVideoTrack &track : tracks_) {
+        AssignDetectionConfidence(track, distance_factor, size_factor);
     }
-
 
     track_map_.clear();
     tracker_map_.clear();

--- a/cpp/motion/SubsenseMotionDetection/StreamingMotionDetection_Subsense.cpp
+++ b/cpp/motion/SubsenseMotionDetection/StreamingMotionDetection_Subsense.cpp
@@ -259,6 +259,16 @@ vector<MPFVideoTrack> SubsenseStreamingDetection::EndSegment() {
         track.frame_locations = std::move(new_locations);
     }
 
+    // Assign a confidence value to each detection
+    float distance_factor = parameters_["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
+    float size_factor = parameters_["SIZE_CONFIDENCE_WEIGHT_FACTOR"].toFloat();
+    if ((distance_factor > 0) || (size_factor > 0)) {
+        for(MPFVideoTrack &track : tracks_) {
+            AssignDetectionConfidence(track, distance_factor, size_factor);
+        }
+    }
+
+
     track_map_.clear();
     tracker_map_.clear();
     tracker_id_ = 0;

--- a/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
@@ -297,13 +297,13 @@
         },
         {
           "name": "DISTANCE_CONFIDENCE_WEIGHT_FACTOR",
-          "description": "When calculating a detection's confidence, the weight given to the distance (in number of frames) between that detection and the frame(s) in the middle of the track. The default value of 0 will result in this distance not being factored into the confidence calculation. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both less than or equal to 0, then the confidence will be assigned a value of -1.",
+          "description": "When calculating a detection's confidence, the weight given to the distance (in number of frames) between that detection and the frame(s) in the middle of the track. It's value must be greater than or equal to 0, and if it is not, it will be set to 0. The default value of 0 will result in this distance not being factored into the confidence calculation. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both equal to 0, then the confidence will be assigned a value of -1.",
           "type": "FLOAT",
           "defaultValue": "0"
         },
         {
           "name": "SIZE_CONFIDENCE_WEIGHT_FACTOR",
-          "description": "When calculating a detection's confidence, the weight given to the size of that detection's bounding box. The default value of 0 will result in the bounding box size not being factored into the confidence calculation. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both less than or equal to 0, then the confidence will be assigned a value of -1.",
+          "description": "When calculating a detection's confidence, the weight given to the size of that detection's bounding box. It's value must be greater than or equal to 0, and if it is not, it will be set to 0. The default value of 0 will result in the bounding box size not being factored into the confidence calculation. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both equal to 0, then the confidence will be assigned a value of -1.",
           "type": "FLOAT",
           "defaultValue": "0"
         },

--- a/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
@@ -297,13 +297,13 @@
         },
         {
           "name": "DISTANCE_CONFIDENCE_WEIGHT_FACTOR",
-          "description": "The weight to be given to the distance of a given detection from the center detection in a track when calculating the confidence of that detection. The default value of 0 will result in the distance from the center detection not being factored into the calculation of confidence. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both set to 0, then the confidence will be assigned a value of -1.",
+          "description": "When calculating a detection's confidence, the weight given to the distance (in number of frames) between that detection and the frame(s) in the middle of the track. The default value of 0 will result in this distance not being factored into the confidence calculation. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both less than or equal to 0, then the confidence will be assigned a value of -1.",
           "type": "FLOAT",
           "defaultValue": "0"
         },
         {
           "name": "SIZE_CONFIDENCE_WEIGHT_FACTOR",
-          "description": "The weight to be given to the size of the bounding box for a given detection in a track when calculating the confidence of that detection. The default value of 0 will result in the size of the bounding box not being factored into the calculation of confidence. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both set to 0, then the confidence will be assigned a value of -1.",
+          "description": "When calculating a detection's confidence, the weight given to the size of that detection's bounding box. The default value of 0 will result in the bounding box size not being factored into the confidence calculation. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both less than or equal to 0, then the confidence will be assigned a value of -1.",
           "type": "FLOAT",
           "defaultValue": "0"
         },

--- a/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
@@ -296,6 +296,18 @@
           "defaultValue": "-1"
         },
         {
+          "name": "DISTANCE_CONFIDENCE_WEIGHT_FACTOR",
+          "description": "The weight to be given to the distance of a given detection from the center detection in a track when calculating the confidence of that detection. The default value of 0 will result in the distance from the center detection not being factored into the calculation of confidence. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both set to 0, then the confidence will be assigned a value of -1.",
+          "type": "FLOAT",
+          "defaultValue": "0"
+        },
+        {
+          "name": "SIZE_CONFIDENCE_WEIGHT_FACTOR",
+          "description": "The weight to be given to the size of the bounding box for a given detection in a track when calculating the confidence of that detection. The default value of 0 will result in the size of the bounding box not being factored into the calculation of confidence. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both set to 0, then the confidence will be assigned a value of -1.",
+          "type": "FLOAT",
+          "defaultValue": "0"
+        },
+        {
           "name": "VERBOSE",
           "description": "0: no debugging output 1: log all track results.",
           "type": "INT",

--- a/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
@@ -111,32 +111,32 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "ROTATION",
           "description": "Specifies the number of degrees in the clockwise direction that the media will be rotated. Only 90, 180 and 270 degrees are supported.",
-          "type": "INT",
+          "type": "STRING",
           "defaultValue": "0"
         },
         {

--- a/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/motion/SubsenseMotionDetection/plugin-files/descriptor/descriptor.json
@@ -297,13 +297,13 @@
         },
         {
           "name": "DISTANCE_CONFIDENCE_WEIGHT_FACTOR",
-          "description": "When calculating a detection's confidence, the weight given to the distance (in number of frames) between that detection and the frame(s) in the middle of the track. It's value must be greater than or equal to 0, and if it is not, it will be set to 0. The default value of 0 will result in this distance not being factored into the confidence calculation. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both equal to 0, then the confidence will be assigned a value of -1.",
+          "description": "When calculating a detection's confidence, the weight given to the distance (in number of frames) between that detection and the frame(s) in the middle of the track. Its value must be greater than or equal to 0, and if it is not, it will be set to 0. The default value of 0 will result in this distance not being factored into the confidence calculation. If this and the SIZE_CONFIDENCE_WEIGHT_FACTOR are both equal to 0, then the confidence will be assigned a value of -1.",
           "type": "FLOAT",
           "defaultValue": "0"
         },
         {
           "name": "SIZE_CONFIDENCE_WEIGHT_FACTOR",
-          "description": "When calculating a detection's confidence, the weight given to the size of that detection's bounding box. It's value must be greater than or equal to 0, and if it is not, it will be set to 0. The default value of 0 will result in the bounding box size not being factored into the confidence calculation. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both equal to 0, then the confidence will be assigned a value of -1.",
+          "description": "When calculating a detection's confidence, the weight given to the size of that detection's bounding box. Its value must be greater than or equal to 0, and if it is not, it will be set to 0. The default value of 0 will result in the bounding box size not being factored into the confidence calculation. If this and the DISTANCE_CONFIDENCE_WEIGHT_FACTOR are both equal to 0, then the confidence will be assigned a value of -1.",
           "type": "FLOAT",
           "defaultValue": "0"
         },

--- a/cpp/motion/SubsenseMotionDetection/sample_subsense_motion_detector.cpp
+++ b/cpp/motion/SubsenseMotionDetection/sample_subsense_motion_detector.cpp
@@ -116,6 +116,8 @@ int processVideo(MPFDetectionComponent *detection_engine, int argc, char* argv[]
     algorithm_properties["USE_MOTION_TRACKING"] = to_string(1);
     // algorithm_properties["VERBOSE"] = to_string(2);
     // algorithm_properties["ROTATION"] = to_string(270);
+    // algorithm_properties["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"] = to_string(0.5);
+    // algorithm_properties["SIZE_CONFIDENCE_WEIGHT_FACTOR"] = to_string(0.5);
 
     MPFVideoJob job("Testing", argv[1], stoi(argv[2]), stoi(argv[3]), algorithm_properties, { });
     vector<MPFVideoTrack> tracks;

--- a/cpp/motion/SubsenseMotionDetection/sample_subsense_motion_detector.cpp
+++ b/cpp/motion/SubsenseMotionDetection/sample_subsense_motion_detector.cpp
@@ -116,8 +116,8 @@ int processVideo(MPFDetectionComponent *detection_engine, int argc, char* argv[]
     algorithm_properties["USE_MOTION_TRACKING"] = to_string(1);
     // algorithm_properties["VERBOSE"] = to_string(2);
     // algorithm_properties["ROTATION"] = to_string(270);
-    // algorithm_properties["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"] = to_string(0.5);
-    // algorithm_properties["SIZE_CONFIDENCE_WEIGHT_FACTOR"] = to_string(0.5);
+    // algorithm_properties["DISTANCE_CONFIDENCE_WEIGHT_FACTOR"] = to_string(0.75);
+    // algorithm_properties["SIZE_CONFIDENCE_WEIGHT_FACTOR"] = to_string(0.25);
 
     MPFVideoJob job("Testing", argv[1], stoi(argv[2]), stoi(argv[3]), algorithm_properties, { });
     vector<MPFVideoTrack> tracks;

--- a/cpp/motion/SubsenseMotionDetection/test/test_subsense_motion_detection.cpp
+++ b/cpp/motion/SubsenseMotionDetection/test/test_subsense_motion_detection.cpp
@@ -201,6 +201,16 @@ TEST(TestAssignConfidence, BothWeightsZero) {
     ASSERT_NEAR(track.frame_locations.begin()->second.confidence, -1.0, 0.000001);
 }
 
+TEST(TestAssignConfidence, NegativeWeight) {
+
+    MPFVideoTrack track = MakeTrack(1);
+    float distance_factor = -0.1;
+    float size_factor = 0.0;
+    AssignDetectionConfidence(track, distance_factor, size_factor);
+    // One weight factor negative: treat it as zero, so no change in confidence
+    ASSERT_NEAR(track.frame_locations.begin()->second.confidence, -1.0, 0.000001);
+}
+
 TEST(TestAssignConfidence, BothWeightsOne) {
 
     MPFVideoTrack track = MakeTrack(5);
@@ -263,6 +273,17 @@ TEST(TestAssignConfidence, DistanceWeightOnlyOddNumDetections) {
     AssignDetectionConfidence(track, distance_factor, size_factor);
     ASSERT_TRUE(CheckTrack(track, {0, 0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25, 0}));
 }
+
+TEST(TestAssignConfidence, DistanceWeightOneSizeWeightNegative) {
+
+    // This test should give the same results as the one above.
+    MPFVideoTrack track = MakeTrack(9);
+    float distance_factor = 1.0;
+    float size_factor = -0.5;
+    AssignDetectionConfidence(track, distance_factor, size_factor);
+    ASSERT_TRUE(CheckTrack(track, {0, 0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25, 0}));
+}
+
 TEST(TestAssignConfidence, SizeWeightOnly) {
 
     MPFVideoTrack track = MakeTrack(8);
@@ -271,6 +292,7 @@ TEST(TestAssignConfidence, SizeWeightOnly) {
     AssignDetectionConfidence(track, distance_factor, size_factor);
     ASSERT_TRUE(CheckTrack(track, {0.015625, 0.0625, 0.140625, 0.25, 0.390625, 0.5625, 0.765625, 1.0}));
 }
+
 TEST(TestAssignConfidence, EqualWeights) {
 
     MPFVideoTrack track = MakeTrack(7);

--- a/cpp/motion/SubsenseMotionDetection/test/test_subsense_motion_detection.cpp
+++ b/cpp/motion/SubsenseMotionDetection/test/test_subsense_motion_detection.cpp
@@ -47,7 +47,7 @@
 #include <MPFSimpleConfigLoader.h>
 
 #include "MotionDetection_Subsense.h"
-#include "AssignDetectionConfidence.h"
+#include "MotionDetectionUtils.h"
 
 using std::string;
 using std::vector;
@@ -176,7 +176,7 @@ TEST(VideoGeneration, TestOnKnownVideo) {
 MPFVideoTrack MakeTrack(int num_detections) {
     MPFVideoTrack track(0, num_detections-1, -1);
     for (int i = 0; i < num_detections; ++i) {
-        track.frame_locations.insert({i, {i+1, i+1, i*5, i*10, -1}});
+        track.frame_locations.insert({i, {i+1, i+1, 5*(i+1), 10*(i+1), -1}});
     }
     return track;
 }
@@ -207,33 +207,25 @@ TEST(TestAssignConfidence, BothWeightsOne) {
     float distance_factor = 1.0;
     float size_factor = 1.0;
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_TRUE(CheckTrack(track, {0, 0.45, 1.0, 0.85, 0.8}));
+    ASSERT_TRUE(CheckTrack(track, {0.0294118, 0.485294, 1.0, 0.838235, 0.735294}));
 }
 
 TEST(TestAssignConfidence, OneDetection) {
 
-    MPFVideoTrack track;
+    MPFVideoTrack track = MakeTrack(1);
     float distance_factor = 0.5;
     float size_factor = 0.5;
-    MPFImageLocation loc(10, 10, 100, 100, -1);
-    track.frame_locations.insert({1, loc});
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_NEAR(track.frame_locations.begin()->second.confidence, 1.0, 0.000001);
+    EXPECT_TRUE(CheckTrack(track, {1.0}));
 }
 
 TEST(TestAssignConfidence, TwoDetections) {
 
-    MPFVideoTrack track;
+    MPFVideoTrack track = MakeTrack(2);
     float distance_factor = 0.25;
     float size_factor = 0.75;
-    MPFImageLocation loc1(10, 10, 100, 100, -1);
-    track.frame_locations.insert({1, loc1});
-    MPFImageLocation loc2(15, 15, 150, 100, -1);
-    track.frame_locations.insert({2, loc2});
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    auto start = track.frame_locations.begin();
-    EXPECT_NEAR(start->second.confidence, 0.75, 0.000001);
-    EXPECT_NEAR((start++)->second.confidence, 0.75, 0.000001);
+    EXPECT_TRUE(CheckTrack(track,{0.4375, 1.0}));
 }
 
 TEST(TestAssignConfidence, NumDetectionEven) {
@@ -242,7 +234,7 @@ TEST(TestAssignConfidence, NumDetectionEven) {
     float distance_factor = 0.4;
     float size_factor = 0.6;
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_TRUE(CheckTrack(track, {0, 0.24263, 0.526077, 0.85034, 0.993197, 0.954648, 0.956916, 1.0}));
+    ASSERT_TRUE(CheckTrack(track, {0.0147783, 0.269294, 0.553366, 0.866995, 1.0, 0.952381, 0.934319, 0.945813}));
 }
 
 TEST(TestAssignConfidence, NumDetectionsOdd) {
@@ -251,7 +243,7 @@ TEST(TestAssignConfidence, NumDetectionsOdd) {
     float distance_factor = 0.4;
     float size_factor = 0.6;
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_TRUE(CheckTrack(track, {0, 0.182292, 0.395833, 0.640625, 0.916667, 0.890625, 0.895833, 0.932292, 1.0}));
+    ASSERT_TRUE(CheckTrack(track, {0.0123457, 0.216049, 0.444444, 0.697531, 0.975309, 0.944444, 0.938272, 0.95679, 1.0}));
 }
 
 TEST(TestAssignConfidence, DistanceWeightOnlyEvenNumDetections) {
@@ -260,7 +252,7 @@ TEST(TestAssignConfidence, DistanceWeightOnlyEvenNumDetections) {
     float distance_factor = 1.0;
     float size_factor = 0;
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_TRUE(CheckTrack(track, {0, 0.333333, 0.666667, 1.0, 1.0, 0.666667, 0.333333, 0}));
+    ASSERT_TRUE(CheckTrack(track, {0, 0.25, 0.5, 0.75, 1.0, 1.0, 0.75, 0.5, 0.25, 0}));
 }
 
 TEST(TestAssignConfidence, DistanceWeightOnlyOddNumDetections) {
@@ -277,14 +269,14 @@ TEST(TestAssignConfidence, SizeWeightOnly) {
     float distance_factor = 0;
     float size_factor = 1.0;
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_TRUE(CheckTrack(track, {0, 0.0204082, 0.0816327, 0.183673, 0.326531, 0.510204, 0.734694, 1.0}));
+    ASSERT_TRUE(CheckTrack(track, {0.015625, 0.0625, 0.140625, 0.25, 0.390625, 0.5625, 0.765625, 1.0}));
 }
 TEST(TestAssignConfidence, EqualWeights) {
 
-    MPFVideoTrack track = MakeTrack(10);
+    MPFVideoTrack track = MakeTrack(7);
     float distance_factor = 0.5;
     float size_factor = 0.5;
     AssignDetectionConfidence(track, distance_factor, size_factor);
-    ASSERT_TRUE(CheckTrack(track, {0, 0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25, 0, 0}));
+    ASSERT_TRUE(CheckTrack(track, {0.0153846, 0.312821, 0.641026, 1.0, 0.88718, 0.805128, 0.753846}));
 }
 

--- a/cpp/motion/SubsenseMotionDetection/test/test_subsense_motion_detection.cpp
+++ b/cpp/motion/SubsenseMotionDetection/test/test_subsense_motion_detection.cpp
@@ -302,3 +302,22 @@ TEST(TestAssignConfidence, EqualWeights) {
     ASSERT_TRUE(CheckTrack(track, {0.0153846, 0.312821, 0.641026, 1.0, 0.88718, 0.805128, 0.753846}));
 }
 
+TEST(TestAssignConfidence, EqualBoundingBoxesAtEqualDistance) {
+
+    MPFVideoTrack track = MakeTrack(5);
+    track.frame_locations.at(1) = track.frame_locations.at(3);
+    float distance_factor = 0.5;
+    float size_factor = 0.5;
+    AssignDetectionConfidence(track, distance_factor, size_factor);
+    ASSERT_NEAR(track.frame_locations.at(1).confidence, track.frame_locations.at(3).confidence, 0.000001);
+}
+
+TEST(TestAssignConfidence, EqualBoundingBoxesAtDifferentDistance) {
+
+    MPFVideoTrack track = MakeTrack(7);
+    track.frame_locations.at(1) = track.frame_locations.at(4);
+    float distance_factor = 0;
+    float size_factor = 1.0;
+    AssignDetectionConfidence(track, distance_factor, size_factor);
+    ASSERT_NEAR(track.frame_locations.at(1).confidence, track.frame_locations.at(4).confidence, 0.000001);
+}

--- a/cpp/motion/Utils/MotionDetectionUtils.cpp
+++ b/cpp/motion/Utils/MotionDetectionUtils.cpp
@@ -229,3 +229,55 @@ cv::Rect Upscale(const cv::Rect &rect,
 bool operator <(const cv::Rect &r1, const cv::Rect &r2) {
     return r1.x != r2.x || r1.y != r2.y || r1.area() < r2.area();
 }
+
+
+void AssignDetectionConfidence(MPF::COMPONENT::MPFVideoTrack &track,
+                               float distance_factor,
+                               float size_factor) {
+    // Distance confidence: Detections closer to the "center" of the
+    // track have higher confidence. Determine which detection is at the center
+    // of the track, and assign it the highest confidence (1.0). The rest of the
+    // detections are assigned a confidence based on their distance
+    // from the "center", with the first and last detections in the
+    // track having confidence equal to 0. If there are an even number of
+    // detections in the track, then the two detections nearest the
+    // track center will both be given confidence equal to 1.0.
+
+    // Size confidence: Detections that have greater area in their
+    // bounding boxes have higher confidence. Each detection has a
+    // size confidence equal to the ratio of the size of its bounding
+    // box to the maximum size bounding box in the track.
+
+    int number_of_detections = track.frame_locations.size();
+    float max_size = 0;
+    for (auto entry: track.frame_locations) {
+        float entry_size = static_cast<float>(entry.second.width * entry.second.height);
+        if (entry_size > max_size) {
+            max_size = entry_size;
+        }
+    }
+
+    if (number_of_detections <= 2) {
+        for (auto &entry : track.frame_locations) {
+            MPFImageLocation &loc = entry.second;
+            loc.confidence = distance_factor + size_factor*(static_cast<float>(loc.height*loc.width)/max_size);
+        }
+    }
+    else {
+        float center = static_cast<float>(number_of_detections)/2.0;
+        int center_index = static_cast<int>(center);
+        float confidence_incr = 1.0/center_index;
+
+        auto first = track.frame_locations.begin();
+        auto last = track.frame_locations.rbegin();
+        for (int i = 0; i <= center_index; ++i) {
+            MPFImageLocation &loc1 = (first++)->second;
+            MPFImageLocation &loc2 = (last++)->second;
+            loc1.confidence = distance_factor*(i*confidence_incr) +
+                              size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
+            loc2.confidence = distance_factor*(i*confidence_incr) +
+                              size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
+        }
+    }
+}
+

--- a/cpp/motion/Utils/MotionDetectionUtils.cpp
+++ b/cpp/motion/Utils/MotionDetectionUtils.cpp
@@ -287,18 +287,13 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
                 max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
                 max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
             }
-            MPFImageLocation &loc1 = (first)->second;
-            loc1.confidence = distance_factor +
-               size_factor*((loc1.height*loc1.width)/max_size);
-            max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
             if (center_index < center) {
-                MPFImageLocation &loc2 = (last)->second;
-                loc2.confidence = distance_factor +
-                                  size_factor*((loc2.height*loc2.width)/max_size);
-                max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
+                MPFImageLocation &loc1 = (first)->second;
+                loc1.confidence = distance_factor +
+                                  size_factor*((loc1.height*loc1.width)/max_size);
+                max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
             }
         }
-
         // Finally, normalize all confidences to between 0 and 1.
         for (auto &entry : track.frame_locations) {
             MPFImageLocation &loc = entry.second;

--- a/cpp/motion/Utils/MotionDetectionUtils.cpp
+++ b/cpp/motion/Utils/MotionDetectionUtils.cpp
@@ -233,7 +233,7 @@ bool operator <(const cv::Rect &r1, const cv::Rect &r2) {
 
 void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
                                float size_factor) {
-    std::cout << "distance_factor = " << distance_factor << " size_factor = " << size_factor << std::endl;
+
     if ((distance_factor <= 0.0) && (size_factor <= 0.0)) return;
 
     // Distance confidence: Detections closer to the "center" of the
@@ -251,7 +251,6 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
     // box to the maximum size bounding box in the track.
 
     int number_of_detections = track.frame_locations.size();
-    std::cout << "number of detections = " << number_of_detections << std::endl;
     float max_size = 0;
     float max_confidence = 0.0;
     for (auto entry: track.frame_locations) {
@@ -260,11 +259,10 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
             max_size = entry_size;
         }
     }
-    std::cout <<"max size = " << max_size << std::endl;
+
     if (number_of_detections <= 2) {
         for (auto &entry : track.frame_locations) {
             MPFImageLocation &loc = entry.second;
-            std::cout << "size = " << static_cast<float>(loc.height*loc.width) << std::endl;
             loc.confidence = distance_factor + size_factor*(static_cast<float>(loc.height*loc.width)/max_size);
             max_confidence = (loc.confidence > max_confidence) ? loc.confidence : max_confidence;
         }
@@ -273,8 +271,6 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
         float center = static_cast<float>(number_of_detections)/2.0;
         int center_index = static_cast<int>(center);
         float confidence_incr = (center_index < center) ? 1.0/center_index : 1.0/(center_index - 1);
-        std::cout << "center = " << center << " center index = " << center_index << std::endl;
-        std::cout << "confidence_incr = " << confidence_incr << std::endl;
 
         auto first = track.frame_locations.begin();
         auto last = track.frame_locations.rbegin();
@@ -295,17 +291,13 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
             }
             max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
             max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
-        std::cout << "confidence 1 = " << loc1.confidence << std::endl;
-        std::cout << "confidence 2 = " << loc2.confidence << std::endl;
         }
     }
 
     // Finally, normalize all confidences to between 0 and 1.
-    std::cout << "max_confidence = " << max_confidence << std::endl;
     for (auto &entry : track.frame_locations) {
         MPFImageLocation &loc = entry.second;
         loc.confidence = loc.confidence/max_confidence;
-        std::cout << "confidence = " << loc.confidence << std::endl;
     }
 }
 

--- a/cpp/motion/Utils/MotionDetectionUtils.cpp
+++ b/cpp/motion/Utils/MotionDetectionUtils.cpp
@@ -254,10 +254,10 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
         // box to the maximum size bounding box in the track.
 
         int number_of_detections = track.frame_locations.size();
-        float max_size = 0;
+        float max_size = 0.0;
         float max_confidence = 0.0;
         for (auto entry: track.frame_locations) {
-            float entry_size = static_cast<float>(entry.second.width * entry.second.height);
+            float entry_size = entry.second.width * entry.second.height;
             if (entry_size > max_size) {
                 max_size = entry_size;
             }
@@ -271,7 +271,7 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
             }
         }
         else {
-            float center = static_cast<float>(number_of_detections)/2.0;
+            float center = number_of_detections/2.0;
             int center_index = static_cast<int>(center);
             float confidence_incr = (center_index < center) ? 1.0/center_index : 1.0/(center_index - 1);
 
@@ -281,20 +281,20 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
                 MPFImageLocation &loc1 = (first++)->second;
                 MPFImageLocation &loc2 = (last++)->second;
                 loc1.confidence = distance_factor*(i*confidence_incr) +
-                                  size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
+                                  size_factor*((loc1.height*loc1.width)/max_size);
                 loc2.confidence = distance_factor*(i*confidence_incr) +
-                                  size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
+                                  size_factor*((loc2.height*loc2.width)/max_size);
                 max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
                 max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
             }
             MPFImageLocation &loc1 = (first)->second;
             loc1.confidence = distance_factor +
-               size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
+               size_factor*((loc1.height*loc1.width)/max_size);
             max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
             if (center_index < center) {
                 MPFImageLocation &loc2 = (last)->second;
                 loc2.confidence = distance_factor +
-                                  size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
+                                  size_factor*((loc2.height*loc2.width)/max_size);
                 max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
             }
         }

--- a/cpp/motion/Utils/MotionDetectionUtils.cpp
+++ b/cpp/motion/Utils/MotionDetectionUtils.cpp
@@ -255,19 +255,15 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
 
         int number_of_detections = track.frame_locations.size();
         float max_size = 0.0;
-        float max_confidence = 0.0;
-        for (auto entry: track.frame_locations) {
+        for (auto &entry: track.frame_locations) {
             float entry_size = entry.second.width * entry.second.height;
-            if (entry_size > max_size) {
-                max_size = entry_size;
-            }
+            max_size = (entry_size > max_size) ? entry_size : max_size;
         }
 
         if (number_of_detections <= 2) {
             for (auto &entry : track.frame_locations) {
                 MPFImageLocation &loc = entry.second;
                 loc.confidence = distance_factor + size_factor*(static_cast<float>(loc.height*loc.width)/max_size);
-                max_confidence = (loc.confidence > max_confidence) ? loc.confidence : max_confidence;
             }
         }
         else {
@@ -284,17 +280,18 @@ void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
                                   size_factor*((loc1.height*loc1.width)/max_size);
                 loc2.confidence = distance_factor*(i*confidence_incr) +
                                   size_factor*((loc2.height*loc2.width)/max_size);
-                max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
-                max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
             }
             if (center_index < center) {
                 MPFImageLocation &loc1 = (first)->second;
                 loc1.confidence = distance_factor +
                                   size_factor*((loc1.height*loc1.width)/max_size);
-                max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
             }
         }
         // Finally, normalize all confidences to between 0 and 1.
+        float max_confidence = 0.0;
+        for (auto &entry : track.frame_locations) {
+            max_confidence = (entry.second.confidence > max_confidence) ? entry.second.confidence : max_confidence;
+        }
         for (auto &entry : track.frame_locations) {
             MPFImageLocation &loc = entry.second;
             loc.confidence = loc.confidence/max_confidence;

--- a/cpp/motion/Utils/MotionDetectionUtils.cpp
+++ b/cpp/motion/Utils/MotionDetectionUtils.cpp
@@ -231,9 +231,11 @@ bool operator <(const cv::Rect &r1, const cv::Rect &r2) {
 }
 
 
-void AssignDetectionConfidence(MPF::COMPONENT::MPFVideoTrack &track,
-                               float distance_factor,
+void AssignDetectionConfidence(MPFVideoTrack &track, float distance_factor,
                                float size_factor) {
+    std::cout << "distance_factor = " << distance_factor << " size_factor = " << size_factor << std::endl;
+    if ((distance_factor <= 0.0) && (size_factor <= 0.0)) return;
+
     // Distance confidence: Detections closer to the "center" of the
     // track have higher confidence. Determine which detection is at the center
     // of the track, and assign it the highest confidence (1.0). The rest of the
@@ -249,35 +251,61 @@ void AssignDetectionConfidence(MPF::COMPONENT::MPFVideoTrack &track,
     // box to the maximum size bounding box in the track.
 
     int number_of_detections = track.frame_locations.size();
+    std::cout << "number of detections = " << number_of_detections << std::endl;
     float max_size = 0;
+    float max_confidence = 0.0;
     for (auto entry: track.frame_locations) {
         float entry_size = static_cast<float>(entry.second.width * entry.second.height);
         if (entry_size > max_size) {
             max_size = entry_size;
         }
     }
-
+    std::cout <<"max size = " << max_size << std::endl;
     if (number_of_detections <= 2) {
         for (auto &entry : track.frame_locations) {
             MPFImageLocation &loc = entry.second;
+            std::cout << "size = " << static_cast<float>(loc.height*loc.width) << std::endl;
             loc.confidence = distance_factor + size_factor*(static_cast<float>(loc.height*loc.width)/max_size);
+            max_confidence = (loc.confidence > max_confidence) ? loc.confidence : max_confidence;
         }
     }
     else {
         float center = static_cast<float>(number_of_detections)/2.0;
         int center_index = static_cast<int>(center);
-        float confidence_incr = 1.0/center_index;
+        float confidence_incr = (center_index < center) ? 1.0/center_index : 1.0/(center_index - 1);
+        std::cout << "center = " << center << " center index = " << center_index << std::endl;
+        std::cout << "confidence_incr = " << confidence_incr << std::endl;
 
         auto first = track.frame_locations.begin();
         auto last = track.frame_locations.rbegin();
         for (int i = 0; i <= center_index; ++i) {
             MPFImageLocation &loc1 = (first++)->second;
             MPFImageLocation &loc2 = (last++)->second;
-            loc1.confidence = distance_factor*(i*confidence_incr) +
+            if (i == center_index) {
+                loc1.confidence = distance_factor +
                               size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
-            loc2.confidence = distance_factor*(i*confidence_incr) +
+                loc2.confidence = distance_factor +
                               size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
+            }
+            else {
+                loc1.confidence = distance_factor*(i*confidence_incr) +
+                                  size_factor*(static_cast<float>(loc1.height*loc1.width)/max_size);
+                loc2.confidence = distance_factor*(i*confidence_incr) +
+                                  size_factor*(static_cast<float>(loc2.height*loc2.width)/max_size);
+            }
+            max_confidence = (loc1.confidence > max_confidence) ? loc1.confidence : max_confidence;
+            max_confidence = (loc2.confidence > max_confidence) ? loc2.confidence : max_confidence;
+        std::cout << "confidence 1 = " << loc1.confidence << std::endl;
+        std::cout << "confidence 2 = " << loc2.confidence << std::endl;
         }
+    }
+
+    // Finally, normalize all confidences to between 0 and 1.
+    std::cout << "max_confidence = " << max_confidence << std::endl;
+    for (auto &entry : track.frame_locations) {
+        MPFImageLocation &loc = entry.second;
+        loc.confidence = loc.confidence/max_confidence;
+        std::cout << "confidence = " << loc.confidence << std::endl;
     }
 }
 

--- a/cpp/motion/Utils/MotionDetectionUtils.h
+++ b/cpp/motion/Utils/MotionDetectionUtils.h
@@ -72,6 +72,9 @@ cv::Rect Upscale(const cv::Rect &rect,
                  int frame_cols, int frame_rows,
                  int downsample_count);
     
+void AssignDetectionConfidence(MPF::COMPONENT::MPFVideoTrack &track,
+                               float distance_factor,
+                               float size_factor);
 
 
 #endif   // OPENMPF_CONTRIB_COMPONENTS_MOTION_UTILS_H

--- a/cpp/motion/Utils/MotionDetectionUtils.h
+++ b/cpp/motion/Utils/MotionDetectionUtils.h
@@ -76,5 +76,4 @@ void AssignDetectionConfidence(MPF::COMPONENT::MPFVideoTrack &track,
                                float distance_factor,
                                float size_factor);
 
-
 #endif   // OPENMPF_CONTRIB_COMPONENTS_MOTION_UTILS_H


### PR DESCRIPTION
Added a confidence calculation for subsense detections based on the distance from the center of the track and the area of the detection bounding box. Added unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-contrib-components/56)
<!-- Reviewable:end -->
